### PR TITLE
Package for pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pypackages__/
 dist/
 build/
 .whl
-*.egg-info/*
+*.egg-info
 
 # Documentation
 docs/build/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,6 @@ keywords:
   - VGT
   - AGT
 license: AGPL-3.0
-commit: 95ccbf0f7d468657ebdf4261bb8d9aa77e720b3c
-version: 0.3.5
-date-released: '2023-02-03'
+commit: 986dae297fef46a187a81b6f457c0db50f05f98f
+version: 0.4.0
+date-released: '2023-04-01'

--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,8 @@ sphinx-inline-tabs = "*"
 pylint = "*"
 sphinx-toolbox = "*"
 sphinx-js = "*"
+build = "*"
+twine = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "81fb40dfb20a8f3babb9c6ae154c69dfaa349e4c98a0b12e1d28c8ba6607a11c"
+            "sha256": "a06838fa7c0b516d2ae80ad5284135a1e192696bed6b43ab1ab6b5c38dbb69f4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -313,11 +313,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa",
-                "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"
+                "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08",
+                "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.2.0"
         },
         "pycparser": {
             "hashes": [
@@ -336,11 +336,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077",
-                "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"
+                "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a",
+                "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.6.0"
+            "version": "==67.6.1"
         },
         "whichcraft": {
             "hashes": [
@@ -358,45 +358,39 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:008b0b65c05993bb08912f644d140530e775cf1c62a072bf9340c2249e613c32",
-                "sha256:0217a9615531c83aeedb12e126611b1b1a3175013bbafe57c702ce40000eb9a0",
-                "sha256:0fb497c6b088818e3395e302e426850f8236d8d9f4ef5b2836feae812a8f699c",
-                "sha256:17ebf6e0b1d07ed009738016abf0d0a0f80388e009d0ac6e0ead26fc162b3b9c",
-                "sha256:311196634bb9333aa06f00fc94f59d3a9fddd2305c2c425d86e406ddc6f2260d",
-                "sha256:3218ab1a7748327e08ef83cca63eea7cf20ea7e2ebcb2522072896e5e2fceedf",
-                "sha256:404d1e284eda9e233c90128697c71acffd55e183d70628aa0bbb0e7a3084ed8b",
-                "sha256:4087e253bd3bbbc3e615ecd0b6dd03c4e6a1e46d152d3be6d2ad08fbad742dcc",
-                "sha256:40f4065745e2c2fa0dff0e7ccd7c166a8ac9748974f960cd39f63d2c19f9231f",
-                "sha256:5334e2ef60d3d9439c08baedaf8b84dc9bb9522d0dacbc10572ef5609ef8db6d",
-                "sha256:604cdba8f1983d0ab78edc29aa71c8df0ada06fb147cea436dc37093a0100a4e",
-                "sha256:6373d7eb813a143cb7795d3e42bd8ed857c82a90571567e681e1b3841a390d16",
-                "sha256:655796a906fa3ca67273011c9805c1e1baa047781fca80feeb710328cdbed87f",
-                "sha256:65c3c06afee96c654e590e046c4a24559e65b0a87dbff256cd4bd6f77e1a33f9",
-                "sha256:696f3d5493eae7359887da55c2afa05acc3db5fc625c49529e84bd9992313296",
-                "sha256:6e972493cdfe4ad0411fd9abfab7d4d800a7317a93928217f1a5de2bb0f0d87a",
-                "sha256:7579960be23d1fddecb53898035a0d112ac858c3554018ce615cefc03024e46d",
-                "sha256:765d703096ca47aa5d93044bf701b00bbce4d903a95b41fff7c3796e747b1f1d",
-                "sha256:7e66f60b0067a10dd289b29dceabd3d0e6d68be1504fc9d0bc209cf07f56d189",
-                "sha256:8a2ffadefd0e7206adc86e492ccc60395f7edb5680adedf17a7ee4205c530df4",
-                "sha256:959697ef2757406bff71467a09d940ca364e724c534efbf3786e86eee8591452",
-                "sha256:9d783213fab61832dbb10d385a319cb0e45451088abd45f95b5bb88ed0acca1a",
-                "sha256:a16025df73d24795a0bde05504911d306307c24a64187752685ff6ea23897cb0",
-                "sha256:a2ad597c8c9e038a5912ac3cf166f82926feff2f6e0dabdab956768de0a258f5",
-                "sha256:bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671",
-                "sha256:d169ccd0756c15bbb2f1acc012f5aab279dffc334d733ca0d9362c5beaebe88e",
-                "sha256:d514c269d1f9f5cd05ddfed15298d6c418129f3f064765295659798349c43e6f",
-                "sha256:d692374b578360d36568dd05efb8a5a67ab6d1878c29c582e37ddba80e66c396",
-                "sha256:dbaeb9cf0ea0b3bc4b36fae54a016933d64c6d52a94810a63c00f440ecb37dd7",
-                "sha256:dc26c8d44472e035d59d6f1177eb712888447f5799743da9c398b0339ed90b1b",
-                "sha256:e1574980b48c8c74f83578d1e77e701f8439a5d93f36a5a0af31337467c08fcf",
-                "sha256:e74a578172525c20d7223eac5f8ad187f10940dac06e40113d62f14f3adb1e8f",
-                "sha256:e945de62917acbf853ab968d8916290548df18dd62c739d862f359ecd25842a6",
-                "sha256:f0980d44b8aded808bec5059018d64692f0127f10510eca71f2f0ace8fb11188",
-                "sha256:f98d4bd7bbb15ca701d19b93263cc5edfd480c3475d163f137385f49e5b3a3a7",
-                "sha256:fb68d212efd057596dee9e6582daded9f8ef776538afdf5feceb3059df2d2e7b"
+                "sha256:042f2381118b093714081fd82c98e3b189b68db38ee7d35b63c327c470ef8373",
+                "sha256:0ec9653825f837fbddc4e4b603d90269b501486c11800d7c761eee7ce46d1bbb",
+                "sha256:12175ca6b4db7621aedd7c30aa7cfa0a2d65ea3a0105393e05482d7a2d367446",
+                "sha256:1592f68ae11e557b9ff2bc96ac8fc30b187e77c45a3c9cd876e3368c53dc5ba8",
+                "sha256:23ac41d52fd15dd8be77e3257bc51bbb82469cf7f5e9a30b75e903e21439d16c",
+                "sha256:424d23b97fa1542d7be882eae0c0fc3d6827784105264a8169a26ce16db260d8",
+                "sha256:4407b1435572e3e1610797c9203ad2753666c62883b921318c5403fb7139dec2",
+                "sha256:48f4d38cf4b462e75fac78b6f11ad47b06b1c568eb59896db5b6ec1094eb467f",
+                "sha256:4c3d7dfd897a588ec27e391edbe3dd320a03684457470415870254e714126b1f",
+                "sha256:5171eb073474a5038321409a630904fd61f12dd1856dd7e9d19cd6fe092cbbc5",
+                "sha256:5a158846d0fca0a908c1afb281ddba88744d403f2550dc34405c3691769cdd85",
+                "sha256:6ee934f023f875ec2cfd2b05a937bd817efcc6c4c3f55c5778cbf78e58362ddc",
+                "sha256:790c1d9d8f9c92819c31ea660cd43c3d5451df1df61e2e814a6f99cebb292788",
+                "sha256:809fe3bf1a91393abc7e92d607976bbb8586512913a79f2bf7d7ec15bd8ea518",
+                "sha256:87b690bbee9876163210fd3f500ee59f5803e4a6607d1b1238833b8885ebd410",
+                "sha256:89086c9d3490a0f265a3c4b794037a84541ff5ffa28bb9c24cc9f66566968464",
+                "sha256:99856d6c98a326abbcc2363827e16bd6044f70f2ef42f453c0bd5440c4ce24e5",
+                "sha256:aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d",
+                "sha256:af169ba897692e9cd984a81cb0f02e46dacdc07d6cf9fd5c91e81f8efaf93d52",
+                "sha256:b39b8711578dcfd45fc0140993403b8a81e879ec25d53189f3faa1f006087dca",
+                "sha256:b3f543ae9d3408549a9900720f18c0194ac0fe810cecda2a584fd4dca2eb3bb8",
+                "sha256:d0583b75f2e70ec93f100931660328965bb9ff65ae54695fb3fa0a1255daa6f2",
+                "sha256:dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f",
+                "sha256:e538f2d4a6ffb6edfb303ce70ae7e88629ac6e5581870e66c306d9ad7b564a58",
+                "sha256:eba51599370c87088d8882ab74f637de0c4f04a6d08a312dce49368ba9ed5c2a",
+                "sha256:ee4b43f35f5dc15e1fec55ccb53c130adb1d11e8ad8263d68b1284b66a04190d",
+                "sha256:f2363e5fd81afb650085c6686f2ee3706975c54f331b426800b53531191fdf28",
+                "sha256:f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990",
+                "sha256:f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995",
+                "sha256:fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.5.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0"
         }
     },
     "develop": {
@@ -433,11 +427,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa",
-                "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"
+                "sha256:89860bda98fe2bbd1f5d262229be7629d778ce280de68d95d4a73d1f592ad268",
+                "sha256:af4e0aff46e2868218502789898269ed95b663fba49e65d91c1e09c966266c34"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.0"
+            "version": "==2.15.1"
         },
         "attrs": {
             "hashes": [
@@ -465,42 +459,58 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39",
-                "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"
+                "sha256:2130a5ad7f513200fae61a17abb5e338ca980fa28c439c0571014bc0217e9591",
+                "sha256:c5fceeaec29d09c84970e47c65f2f0efe57872f7cff494c9691a26ec0ff13234"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.11.2"
+            "version": "==4.12.0"
         },
         "black": {
             "hashes": [
-                "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd",
-                "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555",
-                "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481",
-                "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468",
-                "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9",
-                "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a",
-                "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958",
-                "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580",
-                "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26",
-                "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32",
-                "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8",
-                "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753",
-                "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b",
-                "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074",
-                "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651",
-                "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24",
-                "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6",
-                "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad",
-                "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac",
-                "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221",
-                "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06",
-                "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27",
-                "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648",
-                "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739",
-                "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"
+                "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5",
+                "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915",
+                "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326",
+                "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940",
+                "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b",
+                "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30",
+                "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c",
+                "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c",
+                "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab",
+                "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27",
+                "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2",
+                "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961",
+                "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9",
+                "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb",
+                "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70",
+                "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331",
+                "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2",
+                "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266",
+                "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d",
+                "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6",
+                "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b",
+                "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925",
+                "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8",
+                "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4",
+                "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"
             ],
             "index": "pypi",
-            "version": "==23.1.0"
+            "version": "==23.3.0"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+                "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.0"
+        },
+        "build": {
+            "hashes": [
+                "sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
+                "sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
         },
         "cachecontrol": {
             "extras": [
@@ -706,6 +716,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.4.1"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+                "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.1.0"
+        },
         "iniconfig": {
             "hashes": [
                 "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
@@ -722,6 +740,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==5.12.0"
         },
+        "jaraco.classes": {
+            "hashes": [
+                "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
+                "sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.2.3"
+        },
         "jinja2": {
             "hashes": [
                 "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
@@ -729,6 +755,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.1.2"
+        },
+        "keyring": {
+            "hashes": [
+                "sha256:771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
+                "sha256:ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.13.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -778,6 +812,14 @@
                 "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"
             ],
             "version": "==0.12.2"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
+                "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.0"
         },
         "markupsafe": {
             "hashes": [
@@ -842,6 +884,22 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d",
+                "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==9.1.0"
         },
         "msgpack": {
             "hashes": [
@@ -960,94 +1018,91 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:013016af6b3a12a2f40b704677f8b51f72cb007dac785a9933d5c86a72a7fe33",
-                "sha256:0845adc64fe9886db00f5ab68c4a8cd933ab749a87747555cec1c95acea64b0b",
-                "sha256:0884ba7b515163a1a05440a138adeb722b8a6ae2c2b33aea93ea3118dd3a899e",
-                "sha256:09b89ddc95c248ee788328528e6a2996e09eaccddeeb82a5356e92645733be35",
-                "sha256:0dd4c681b82214b36273c18ca7ee87065a50e013112eea7d78c7a1b89a739153",
-                "sha256:0e51f608da093e5d9038c592b5b575cadc12fd748af1479b5e858045fff955a9",
-                "sha256:0f3269304c1a7ce82f1759c12ce731ef9b6e95b6df829dccd9fe42912cc48569",
-                "sha256:16a8df99701f9095bea8a6c4b3197da105df6f74e6176c5b410bc2df2fd29a57",
-                "sha256:19005a8e58b7c1796bc0167862b1f54a64d3b44ee5d48152b06bb861458bc0f8",
-                "sha256:1b4b4e9dda4f4e4c4e6896f93e84a8f0bcca3b059de9ddf67dac3c334b1195e1",
-                "sha256:28676836c7796805914b76b1837a40f76827ee0d5398f72f7dcc634bae7c6264",
-                "sha256:2968c58feca624bb6c8502f9564dd187d0e1389964898f5e9e1fbc8533169157",
-                "sha256:3f4cc516e0b264c8d4ccd6b6cbc69a07c6d582d8337df79be1e15a5056b258c9",
-                "sha256:3fa1284762aacca6dc97474ee9c16f83990b8eeb6697f2ba17140d54b453e133",
-                "sha256:43521ce2c4b865d385e78579a082b6ad1166ebed2b1a2293c3be1d68dd7ca3b9",
-                "sha256:451f10ef963918e65b8869e17d67db5e2f4ab40e716ee6ce7129b0cde2876eab",
-                "sha256:46c259e87199041583658457372a183636ae8cd56dbf3f0755e0f376a7f9d0e6",
-                "sha256:46f39cab8bbf4a384ba7cb0bc8bae7b7062b6a11cfac1ca4bc144dea90d4a9f5",
-                "sha256:519e14e2c49fcf7616d6d2cfc5c70adae95682ae20f0395e9280db85e8d6c4df",
-                "sha256:53dcb50fbdc3fb2c55431a9b30caeb2f7027fcd2aeb501459464f0214200a503",
-                "sha256:54614444887e0d3043557d9dbc697dbb16cfb5a35d672b7a0fcc1ed0cf1c600b",
-                "sha256:575d8912dca808edd9acd6f7795199332696d3469665ef26163cd090fa1f8bfa",
-                "sha256:5dd5a9c3091a0f414a963d427f920368e2b6a4c2f7527fdd82cde8ef0bc7a327",
-                "sha256:5f532a2ad4d174eb73494e7397988e22bf427f91acc8e6ebf5bb10597b49c493",
-                "sha256:60e7da3a3ad1812c128750fc1bc14a7ceeb8d29f77e0a2356a8fb2aa8925287d",
-                "sha256:653d7fb2df65efefbcbf81ef5fe5e5be931f1ee4332c2893ca638c9b11a409c4",
-                "sha256:6663977496d616b618b6cfa43ec86e479ee62b942e1da76a2c3daa1c75933ef4",
-                "sha256:6abfb51a82e919e3933eb137e17c4ae9c0475a25508ea88993bb59faf82f3b35",
-                "sha256:6c6b1389ed66cdd174d040105123a5a1bc91d0aa7059c7261d20e583b6d8cbd2",
-                "sha256:6d9dfb9959a3b0039ee06c1a1a90dc23bac3b430842dcb97908ddde05870601c",
-                "sha256:765cb54c0b8724a7c12c55146ae4647e0274a839fb6de7bcba841e04298e1011",
-                "sha256:7a21222644ab69ddd9967cfe6f2bb420b460dae4289c9d40ff9a4896e7c35c9a",
-                "sha256:7ac7594397698f77bce84382929747130765f66406dc2cd8b4ab4da68ade4c6e",
-                "sha256:7cfc287da09f9d2a7ec146ee4d72d6ea1342e770d975e49a8621bf54eaa8f30f",
-                "sha256:83125753a60cfc8c412de5896d10a0a405e0bd88d0470ad82e0869ddf0cb3848",
-                "sha256:847b114580c5cc9ebaf216dd8c8dbc6b00a3b7ab0131e173d7120e6deade1f57",
-                "sha256:87708d78a14d56a990fbf4f9cb350b7d89ee8988705e58e39bdf4d82c149210f",
-                "sha256:8a2b5874d17e72dfb80d917213abd55d7e1ed2479f38f001f264f7ce7bae757c",
-                "sha256:8f127e7b028900421cad64f51f75c051b628db17fb00e099eb148761eed598c9",
-                "sha256:94cdff45173b1919350601f82d61365e792895e3c3a3443cf99819e6fbf717a5",
-                "sha256:99d92d148dd03fd19d16175b6d355cc1b01faf80dae93c6c3eb4163709edc0a9",
-                "sha256:9a3049a10261d7f2b6514d35bbb7a4dfc3ece4c4de14ef5876c4b7a23a0e566d",
-                "sha256:9d9a62576b68cd90f7075876f4e8444487db5eeea0e4df3ba298ee38a8d067b0",
-                "sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1",
-                "sha256:a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e",
-                "sha256:a2e0f87144fcbbe54297cae708c5e7f9da21a4646523456b00cc956bd4c65815",
-                "sha256:a4dfdae195335abb4e89cc9762b2edc524f3c6e80d647a9a81bf81e17e3fb6f0",
-                "sha256:a96e6e23f2b79433390273eaf8cc94fec9c6370842e577ab10dabdcc7ea0a66b",
-                "sha256:aabdab8ec1e7ca7f1434d042bf8b1e92056245fb179790dc97ed040361f16bfd",
-                "sha256:b222090c455d6d1a64e6b7bb5f4035c4dff479e22455c9eaa1bdd4c75b52c80c",
-                "sha256:b52ff4f4e002f828ea6483faf4c4e8deea8d743cf801b74910243c58acc6eda3",
-                "sha256:b70756ec9417c34e097f987b4d8c510975216ad26ba6e57ccb53bc758f490dab",
-                "sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858",
-                "sha256:b9b752ab91e78234941e44abdecc07f1f0d8f51fb62941d32995b8161f68cfe5",
-                "sha256:ba6612b6548220ff5e9df85261bddc811a057b0b465a1226b39bfb8550616aee",
-                "sha256:bd752c5ff1b4a870b7661234694f24b1d2b9076b8bf337321a814c612665f343",
-                "sha256:c3c4ed2ff6760e98d262e0cc9c9a7f7b8a9f61aa4d47c58835cdaf7b0b8811bb",
-                "sha256:c5c1362c14aee73f50143d74389b2c158707b4abce2cb055b7ad37ce60738d47",
-                "sha256:cb362e3b0976dc994857391b776ddaa8c13c28a16f80ac6522c23d5257156bed",
-                "sha256:d197df5489004db87d90b918033edbeee0bd6df3848a204bca3ff0a903bef837",
-                "sha256:d3b56206244dc8711f7e8b7d6cad4663917cd5b2d950799425076681e8766286",
-                "sha256:d5b2f8a31bd43e0f18172d8ac82347c8f37ef3e0b414431157718aa234991b28",
-                "sha256:d7081c084ceb58278dd3cf81f836bc818978c0ccc770cbbb202125ddabec6628",
-                "sha256:db74f5562c09953b2c5f8ec4b7dfd3f5421f31811e97d1dbc0a7c93d6e3a24df",
-                "sha256:df41112ccce5d47770a0c13651479fbcd8793f34232a2dd9faeccb75eb5d0d0d",
-                "sha256:e1339790c083c5a4de48f688b4841f18df839eb3c9584a770cbd818b33e26d5d",
-                "sha256:e621b0246192d3b9cb1dc62c78cfa4c6f6d2ddc0ec207d43c0dedecb914f152a",
-                "sha256:e8c5cf126889a4de385c02a2c3d3aba4b00f70234bfddae82a5eaa3ee6d5e3e6",
-                "sha256:e9d7747847c53a16a729b6ee5e737cf170f7a16611c143d95aa60a109a59c336",
-                "sha256:eaef5d2de3c7e9b21f1e762f289d17b726c2239a42b11e25446abf82b26ac132",
-                "sha256:ed3e4b4e1e6de75fdc16d3259098de7c6571b1a6cc863b1a49e7d3d53e036070",
-                "sha256:ef21af928e807f10bf4141cad4746eee692a0dd3ff56cfb25fce076ec3cc8abe",
-                "sha256:f09598b416ba39a8f489c124447b007fe865f786a89dbfa48bb5cf395693132a",
-                "sha256:f0caf4a5dcf610d96c3bd32932bfac8aee61c96e60481c2a0ea58da435e25acd",
-                "sha256:f6e78171be3fb7941f9910ea15b4b14ec27725865a73c15277bc39f5ca4f8391",
-                "sha256:f715c32e774a60a337b2bb8ad9839b4abf75b267a0f18806f6f4f5f1688c4b5a",
-                "sha256:fb5c1ad6bad98c57482236a21bf985ab0ef42bd51f7ad4e4538e89a997624e12"
+                "sha256:07999f5834bdc404c442146942a2ecadd1cb6292f5229f4ed3b31e0a108746b1",
+                "sha256:0852ddb76d85f127c135b6dd1f0bb88dbb9ee990d2cd9aa9e28526c93e794fba",
+                "sha256:1781a624c229cb35a2ac31cc4a77e28cafc8900733a864870c49bfeedacd106a",
+                "sha256:1e7723bd90ef94eda669a3c2c19d549874dd5badaeefabefd26053304abe5799",
+                "sha256:229e2c79c00e85989a34b5981a2b67aa079fd08c903f0aaead522a1d68d79e51",
+                "sha256:22baf0c3cf0c7f26e82d6e1adf118027afb325e703922c8dfc1d5d0156bb2eeb",
+                "sha256:252a03f1bdddce077eff2354c3861bf437c892fb1832f75ce813ee94347aa9b5",
+                "sha256:2dfaaf10b6172697b9bceb9a3bd7b951819d1ca339a5ef294d1f1ac6d7f63270",
+                "sha256:322724c0032af6692456cd6ed554bb85f8149214d97398bb80613b04e33769f6",
+                "sha256:35f6e77122a0c0762268216315bf239cf52b88865bba522999dc38f1c52b9b47",
+                "sha256:375f6e5ee9620a271acb6820b3d1e94ffa8e741c0601db4c0c4d3cb0a9c224bf",
+                "sha256:3ded42b9ad70e5f1754fb7c2e2d6465a9c842e41d178f262e08b8c85ed8a1d8e",
+                "sha256:432b975c009cf649420615388561c0ce7cc31ce9b2e374db659ee4f7d57a1f8b",
+                "sha256:482877592e927fd263028c105b36272398e3e1be3269efda09f6ba21fd83ec66",
+                "sha256:489f8389261e5ed43ac8ff7b453162af39c3e8abd730af8363587ba64bb2e865",
+                "sha256:54f7102ad31a3de5666827526e248c3530b3a33539dbda27c6843d19d72644ec",
+                "sha256:560737e70cb9c6255d6dcba3de6578a9e2ec4b573659943a5e7e4af13f298f5c",
+                "sha256:5671583eab84af046a397d6d0ba25343c00cd50bce03787948e0fff01d4fd9b1",
+                "sha256:5ba1b81ee69573fe7124881762bb4cd2e4b6ed9dd28c9c60a632902fe8db8b38",
+                "sha256:5d4ebf8e1db4441a55c509c4baa7a0587a0210f7cd25fcfe74dbbce7a4bd1906",
+                "sha256:60037a8db8750e474af7ffc9faa9b5859e6c6d0a50e55c45576bf28be7419705",
+                "sha256:608488bdcbdb4ba7837461442b90ea6f3079397ddc968c31265c1e056964f1ef",
+                "sha256:6608ff3bf781eee0cd14d0901a2b9cc3d3834516532e3bd673a0a204dc8615fc",
+                "sha256:662da1f3f89a302cc22faa9f14a262c2e3951f9dbc9617609a47521c69dd9f8f",
+                "sha256:7002d0797a3e4193c7cdee3198d7c14f92c0836d6b4a3f3046a64bd1ce8df2bf",
+                "sha256:763782b2e03e45e2c77d7779875f4432e25121ef002a41829d8868700d119392",
+                "sha256:77165c4a5e7d5a284f10a6efaa39a0ae8ba839da344f20b111d62cc932fa4e5d",
+                "sha256:7c9af5a3b406a50e313467e3565fc99929717f780164fe6fbb7704edba0cebbe",
+                "sha256:7ec6f6ce99dab90b52da21cf0dc519e21095e332ff3b399a357c187b1a5eee32",
+                "sha256:833b86a98e0ede388fa29363159c9b1a294b0905b5128baf01db683672f230f5",
+                "sha256:84a6f19ce086c1bf894644b43cd129702f781ba5751ca8572f08aa40ef0ab7b7",
+                "sha256:8507eda3cd0608a1f94f58c64817e83ec12fa93a9436938b191b80d9e4c0fc44",
+                "sha256:85ec677246533e27770b0de5cf0f9d6e4ec0c212a1f89dfc941b64b21226009d",
+                "sha256:8aca1152d93dcc27dc55395604dcfc55bed5f25ef4c98716a928bacba90d33a3",
+                "sha256:8d935f924bbab8f0a9a28404422da8af4904e36d5c33fc6f677e4c4485515625",
+                "sha256:8f36397bf3f7d7c6a3abdea815ecf6fd14e7fcd4418ab24bae01008d8d8ca15e",
+                "sha256:91ec6fe47b5eb5a9968c79ad9ed78c342b1f97a091677ba0e012701add857829",
+                "sha256:965e4a05ef364e7b973dd17fc765f42233415974d773e82144c9bbaaaea5d089",
+                "sha256:96e88745a55b88a7c64fa49bceff363a1a27d9a64e04019c2281049444a571e3",
+                "sha256:99eb6cafb6ba90e436684e08dad8be1637efb71c4f2180ee6b8f940739406e78",
+                "sha256:9adf58f5d64e474bed00d69bcd86ec4bcaa4123bfa70a65ce72e424bfb88ed96",
+                "sha256:9b1af95c3a967bf1da94f253e56b6286b50af23392a886720f563c547e48e964",
+                "sha256:a0aa9417994d91301056f3d0038af1199eb7adc86e646a36b9e050b06f526597",
+                "sha256:a0f9bb6c80e6efcde93ffc51256d5cfb2155ff8f78292f074f60f9e70b942d99",
+                "sha256:a127ae76092974abfbfa38ca2d12cbeddcdeac0fb71f9627cc1135bedaf9d51a",
+                "sha256:aaf305d6d40bd9632198c766fb64f0c1a83ca5b667f16c1e79e1661ab5060140",
+                "sha256:aca1c196f407ec7cf04dcbb15d19a43c507a81f7ffc45b690899d6a76ac9fda7",
+                "sha256:ace6ca218308447b9077c14ea4ef381ba0b67ee78d64046b3f19cf4e1139ad16",
+                "sha256:b416f03d37d27290cb93597335a2f85ed446731200705b22bb927405320de903",
+                "sha256:bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1",
+                "sha256:c1170d6b195555644f0616fd6ed929dfcf6333b8675fcca044ae5ab110ded296",
+                "sha256:c380b27d041209b849ed246b111b7c166ba36d7933ec6e41175fd15ab9eb1572",
+                "sha256:c446d2245ba29820d405315083d55299a796695d747efceb5717a8b450324115",
+                "sha256:c830a02caeb789633863b466b9de10c015bded434deb3ec87c768e53752ad22a",
+                "sha256:cb841572862f629b99725ebaec3287fc6d275be9b14443ea746c1dd325053cbd",
+                "sha256:cfa4561277f677ecf651e2b22dc43e8f5368b74a25a8f7d1d4a3a243e573f2d4",
+                "sha256:cfcc2c53c06f2ccb8976fb5c71d448bdd0a07d26d8e07e321c103416444c7ad1",
+                "sha256:d3c6b54e304c60c4181da1c9dadf83e4a54fd266a99c70ba646a9baa626819eb",
+                "sha256:d3d403753c9d5adc04d4694d35cf0391f0f3d57c8e0030aac09d7678fa8030aa",
+                "sha256:d9c206c29b46cfd343ea7cdfe1232443072bbb270d6a46f59c259460db76779a",
+                "sha256:e49eb4e95ff6fd7c0c402508894b1ef0e01b99a44320ba7d8ecbabefddcc5569",
+                "sha256:f8286396b351785801a976b1e85ea88e937712ee2c3ac653710a4a57a8da5d9c",
+                "sha256:f8fc330c3370a81bbf3f88557097d1ea26cd8b019d6433aa59f71195f5ddebbf",
+                "sha256:fbd359831c1657d69bb81f0db962905ee05e5e9451913b18b831febfe0519082",
+                "sha256:fe7e1c262d3392afcf5071df9afa574544f28eac825284596ac6db56e6d11062",
+                "sha256:fed1e1cf6a42577953abbe8e6cf2fe2f566daebde7c34724ec8803c4c0cda579"
             ],
             "index": "pypi",
-            "version": "==9.4.0"
+            "version": "==9.5.0"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+                "sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.9.6"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa",
-                "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"
+                "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08",
+                "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.2.0"
         },
         "pluggy": {
             "hashes": [
@@ -1109,19 +1164,27 @@
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [
-                "sha256:29d052eb73e0ab8f137f11df8e73d464c1c6d4c3044d9dc8df2af44639d8bfbf",
-                "sha256:bd578781cd6a33ef713584bf3726f7cd60a3e656ec08a6cc7971e39990808cc0"
+                "sha256:ab56c192e7cd4472ff6b840cda4fc42bceccc7fb4234f064fc834a3248c0afdd",
+                "sha256:d2ea40a7105651aa525bfe5fe309aa264d4d9bb49f839b862243dcf0a56c34cd"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.0"
+            "version": "==2023.1"
         },
         "pylint": {
             "hashes": [
-                "sha256:1460829b6397cb5eb0cdb0b4fc4b556348e515cdca32115f74a1eb7c20b896b4",
-                "sha256:e097d8325f8c88e14ad12844e3fe2d963d3de871ea9a8f8ad25ab1c109889ddc"
+                "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700",
+                "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"
             ],
             "index": "pypi",
-            "version": "==2.17.0"
+            "version": "==2.17.1"
+        },
+        "pyproject-hooks": {
+            "hashes": [
+                "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
+                "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.0"
         },
         "pytest": {
             "hashes": [
@@ -1139,99 +1202,79 @@
             "markers": "sys_platform == 'win32'",
             "version": "==0.2.0"
         },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
+                "sha256:f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==37.3"
+        },
         "regex": {
             "hashes": [
-                "sha256:052b670fafbe30966bbe5d025e90b2a491f85dfe5b2583a163b5e60a85a321ad",
-                "sha256:0653d012b3bf45f194e5e6a41df9258811ac8fc395579fa82958a8b76286bea4",
-                "sha256:0a069c8483466806ab94ea9068c34b200b8bfc66b6762f45a831c4baaa9e8cdd",
-                "sha256:0cf0da36a212978be2c2e2e2d04bdff46f850108fccc1851332bcae51c8907cc",
-                "sha256:131d4be09bea7ce2577f9623e415cab287a3c8e0624f778c1d955ec7c281bd4d",
-                "sha256:144486e029793a733e43b2e37df16a16df4ceb62102636ff3db6033994711066",
-                "sha256:1ddf14031a3882f684b8642cb74eea3af93a2be68893901b2b387c5fd92a03ec",
-                "sha256:1eba476b1b242620c266edf6325b443a2e22b633217a9835a52d8da2b5c051f9",
-                "sha256:20f61c9944f0be2dc2b75689ba409938c14876c19d02f7585af4460b6a21403e",
-                "sha256:22960019a842777a9fa5134c2364efaed5fbf9610ddc5c904bd3a400973b0eb8",
-                "sha256:22e7ebc231d28393dfdc19b185d97e14a0f178bedd78e85aad660e93b646604e",
-                "sha256:23cbb932cc53a86ebde0fb72e7e645f9a5eec1a5af7aa9ce333e46286caef783",
-                "sha256:29c04741b9ae13d1e94cf93fca257730b97ce6ea64cfe1eba11cf9ac4e85afb6",
-                "sha256:2bde29cc44fa81c0a0c8686992c3080b37c488df167a371500b2a43ce9f026d1",
-                "sha256:2cdc55ca07b4e70dda898d2ab7150ecf17c990076d3acd7a5f3b25cb23a69f1c",
-                "sha256:370f6e97d02bf2dd20d7468ce4f38e173a124e769762d00beadec3bc2f4b3bc4",
-                "sha256:395161bbdbd04a8333b9ff9763a05e9ceb4fe210e3c7690f5e68cedd3d65d8e1",
-                "sha256:44136355e2f5e06bf6b23d337a75386371ba742ffa771440b85bed367c1318d1",
-                "sha256:44a6c2f6374e0033873e9ed577a54a3602b4f609867794c1a3ebba65e4c93ee7",
-                "sha256:4919899577ba37f505aaebdf6e7dc812d55e8f097331312db7f1aab18767cce8",
-                "sha256:4b4b1fe58cd102d75ef0552cf17242705ce0759f9695334a56644ad2d83903fe",
-                "sha256:4bdd56ee719a8f751cf5a593476a441c4e56c9b64dc1f0f30902858c4ef8771d",
-                "sha256:4bf41b8b0a80708f7e0384519795e80dcb44d7199a35d52c15cc674d10b3081b",
-                "sha256:4cac3405d8dda8bc6ed499557625585544dd5cbf32072dcc72b5a176cb1271c8",
-                "sha256:4fe7fda2fe7c8890d454f2cbc91d6c01baf206fbc96d89a80241a02985118c0c",
-                "sha256:50921c140561d3db2ab9f5b11c5184846cde686bb5a9dc64cae442926e86f3af",
-                "sha256:5217c25229b6a85049416a5c1e6451e9060a1edcf988641e309dbe3ab26d3e49",
-                "sha256:5352bea8a8f84b89d45ccc503f390a6be77917932b1c98c4cdc3565137acc714",
-                "sha256:542e3e306d1669b25936b64917285cdffcd4f5c6f0247636fec037187bd93542",
-                "sha256:543883e3496c8b6d58bd036c99486c3c8387c2fc01f7a342b760c1ea3158a318",
-                "sha256:586b36ebda81e6c1a9c5a5d0bfdc236399ba6595e1397842fd4a45648c30f35e",
-                "sha256:597f899f4ed42a38df7b0e46714880fb4e19a25c2f66e5c908805466721760f5",
-                "sha256:5a260758454580f11dd8743fa98319bb046037dfab4f7828008909d0aa5292bc",
-                "sha256:5aefb84a301327ad115e9d346c8e2760009131d9d4b4c6b213648d02e2abe144",
-                "sha256:5e6a5567078b3eaed93558842346c9d678e116ab0135e22eb72db8325e90b453",
-                "sha256:5ff525698de226c0ca743bfa71fc6b378cda2ddcf0d22d7c37b1cc925c9650a5",
-                "sha256:61edbca89aa3f5ef7ecac8c23d975fe7261c12665f1d90a6b1af527bba86ce61",
-                "sha256:659175b2144d199560d99a8d13b2228b85e6019b6e09e556209dfb8c37b78a11",
-                "sha256:6a9a19bea8495bb419dc5d38c4519567781cd8d571c72efc6aa959473d10221a",
-                "sha256:6b30bddd61d2a3261f025ad0f9ee2586988c6a00c780a2fb0a92cea2aa702c54",
-                "sha256:6ffd55b5aedc6f25fd8d9f905c9376ca44fcf768673ffb9d160dd6f409bfda73",
-                "sha256:702d8fc6f25bbf412ee706bd73019da5e44a8400861dfff7ff31eb5b4a1276dc",
-                "sha256:74bcab50a13960f2a610cdcd066e25f1fd59e23b69637c92ad470784a51b1347",
-                "sha256:75f591b2055523fc02a4bbe598aa867df9e953255f0b7f7715d2a36a9c30065c",
-                "sha256:763b64853b0a8f4f9cfb41a76a4a85a9bcda7fdda5cb057016e7706fde928e66",
-                "sha256:76c598ca73ec73a2f568e2a72ba46c3b6c8690ad9a07092b18e48ceb936e9f0c",
-                "sha256:78d680ef3e4d405f36f0d6d1ea54e740366f061645930072d39bca16a10d8c93",
-                "sha256:7b280948d00bd3973c1998f92e22aa3ecb76682e3a4255f33e1020bd32adf443",
-                "sha256:7db345956ecce0c99b97b042b4ca7326feeec6b75facd8390af73b18e2650ffc",
-                "sha256:7dbdce0c534bbf52274b94768b3498abdf675a691fec5f751b6057b3030f34c1",
-                "sha256:7ef6b5942e6bfc5706301a18a62300c60db9af7f6368042227ccb7eeb22d0892",
-                "sha256:7f5a3ffc731494f1a57bd91c47dc483a1e10048131ffb52d901bfe2beb6102e8",
-                "sha256:8a45b6514861916c429e6059a55cf7db74670eaed2052a648e3e4d04f070e001",
-                "sha256:8ad241da7fac963d7573cc67a064c57c58766b62a9a20c452ca1f21050868dfa",
-                "sha256:8b0886885f7323beea6f552c28bff62cbe0983b9fbb94126531693ea6c5ebb90",
-                "sha256:8ca88da1bd78990b536c4a7765f719803eb4f8f9971cc22d6ca965c10a7f2c4c",
-                "sha256:8e0caeff18b96ea90fc0eb6e3bdb2b10ab5b01a95128dfeccb64a7238decf5f0",
-                "sha256:957403a978e10fb3ca42572a23e6f7badff39aa1ce2f4ade68ee452dc6807692",
-                "sha256:9af69f6746120998cd9c355e9c3c6aec7dff70d47247188feb4f829502be8ab4",
-                "sha256:9c94f7cc91ab16b36ba5ce476f1904c91d6c92441f01cd61a8e2729442d6fcf5",
-                "sha256:a37d51fa9a00d265cf73f3de3930fa9c41548177ba4f0faf76e61d512c774690",
-                "sha256:a3a98921da9a1bf8457aeee6a551948a83601689e5ecdd736894ea9bbec77e83",
-                "sha256:a3c1ebd4ed8e76e886507c9eddb1a891673686c813adf889b864a17fafcf6d66",
-                "sha256:a5f9505efd574d1e5b4a76ac9dd92a12acb2b309551e9aa874c13c11caefbe4f",
-                "sha256:a8ff454ef0bb061e37df03557afda9d785c905dab15584860f982e88be73015f",
-                "sha256:a9d0b68ac1743964755ae2d89772c7e6fb0118acd4d0b7464eaf3921c6b49dd4",
-                "sha256:aa62a07ac93b7cb6b7d0389d8ef57ffc321d78f60c037b19dfa78d6b17c928ee",
-                "sha256:ac741bf78b9bb432e2d314439275235f41656e189856b11fb4e774d9f7246d81",
-                "sha256:ae1e96785696b543394a4e3f15f3f225d44f3c55dafe3f206493031419fedf95",
-                "sha256:b683e5fd7f74fb66e89a1ed16076dbab3f8e9f34c18b1979ded614fe10cdc4d9",
-                "sha256:b7a8b43ee64ca8f4befa2bea4083f7c52c92864d8518244bfa6e88c751fa8fff",
-                "sha256:b8e38472739028e5f2c3a4aded0ab7eadc447f0d84f310c7a8bb697ec417229e",
-                "sha256:bfff48c7bd23c6e2aec6454aaf6edc44444b229e94743b34bdcdda2e35126cf5",
-                "sha256:c14b63c9d7bab795d17392c7c1f9aaabbffd4cf4387725a0ac69109fb3b550c6",
-                "sha256:c27cc1e4b197092e50ddbf0118c788d9977f3f8f35bfbbd3e76c1846a3443df7",
-                "sha256:c28d3309ebd6d6b2cf82969b5179bed5fefe6142c70f354ece94324fa11bf6a1",
-                "sha256:c670f4773f2f6f1957ff8a3962c7dd12e4be54d05839b216cb7fd70b5a1df394",
-                "sha256:ce6910b56b700bea7be82c54ddf2e0ed792a577dfaa4a76b9af07d550af435c6",
-                "sha256:d0213671691e341f6849bf33cd9fad21f7b1cb88b89e024f33370733fec58742",
-                "sha256:d03fe67b2325cb3f09be029fd5da8df9e6974f0cde2c2ac6a79d2634e791dd57",
-                "sha256:d0e5af9a9effb88535a472e19169e09ce750c3d442fb222254a276d77808620b",
-                "sha256:d243b36fbf3d73c25e48014961e83c19c9cc92530516ce3c43050ea6276a2ab7",
-                "sha256:d26166acf62f731f50bdd885b04b38828436d74e8e362bfcb8df221d868b5d9b",
-                "sha256:d403d781b0e06d2922435ce3b8d2376579f0c217ae491e273bab8d092727d244",
-                "sha256:d8716f82502997b3d0895d1c64c3b834181b1eaca28f3f6336a71777e437c2af",
-                "sha256:e4f781ffedd17b0b834c8731b75cce2639d5a8afe961c1e58ee7f1f20b3af185",
-                "sha256:e613a98ead2005c4ce037c7b061f2409a1a4e45099edb0ef3200ee26ed2a69a8",
-                "sha256:ef4163770525257876f10e8ece1cf25b71468316f61451ded1a6f44273eedeb5"
+                "sha256:086afe222d58b88b62847bdbd92079b4699350b4acab892f88a935db5707c790",
+                "sha256:0b8eb1e3bca6b48dc721818a60ae83b8264d4089a4a41d62be6d05316ec38e15",
+                "sha256:11d00c31aeab9a6e0503bc77e73ed9f4527b3984279d997eb145d7c7be6268fd",
+                "sha256:11d1f2b7a0696dc0310de0efb51b1f4d813ad4401fe368e83c0c62f344429f98",
+                "sha256:1b1fc2632c01f42e06173d8dd9bb2e74ab9b0afa1d698058c867288d2c7a31f3",
+                "sha256:20abe0bdf03630fe92ccafc45a599bca8b3501f48d1de4f7d121153350a2f77d",
+                "sha256:22720024b90a6ba673a725dcc62e10fb1111b889305d7c6b887ac7466b74bedb",
+                "sha256:2472428efc4127374f494e570e36b30bb5e6b37d9a754f7667f7073e43b0abdd",
+                "sha256:25f0532fd0c53e96bad84664171969de9673b4131f2297f1db850d3918d58858",
+                "sha256:2848bf76673c83314068241c8d5b7fa9ad9bed866c979875a0e84039349e8fa7",
+                "sha256:37ae17d3be44c0b3f782c28ae9edd8b47c1f1776d4cabe87edc0b98e1f12b021",
+                "sha256:3cd9f5dd7b821f141d3a6ca0d5d9359b9221e4f051ca3139320adea9f1679691",
+                "sha256:4479f9e2abc03362df4045b1332d4a2b7885b245a30d4f4b051c4083b97d95d8",
+                "sha256:4c49552dc938e3588f63f8a78c86f3c9c75301e813bca0bef13bdb4b87ccf364",
+                "sha256:539dd010dc35af935b32f248099e38447bbffc10b59c2b542bceead2bed5c325",
+                "sha256:54c3fa855a3f7438149de3211738dd9b5f0c733f48b54ae05aa7fce83d48d858",
+                "sha256:55ae114da21b7a790b90255ea52d2aa3a0d121a646deb2d3c6a3194e722fc762",
+                "sha256:5ccfafd98473e007cebf7da10c1411035b7844f0f204015efd050601906dbb53",
+                "sha256:5fc33b27b1d800fc5b78d7f7d0f287e35079ecabe68e83d46930cf45690e1c8c",
+                "sha256:6560776ec19c83f3645bbc5db64a7a5816c9d8fb7ed7201c5bcd269323d88072",
+                "sha256:6572ff287176c0fb96568adb292674b421fa762153ed074d94b1d939ed92c253",
+                "sha256:6b190a339090e6af25f4a5fd9e77591f6d911cc7b96ecbb2114890b061be0ac1",
+                "sha256:7304863f3a652dab5e68e6fb1725d05ebab36ec0390676d1736e0571ebb713ef",
+                "sha256:75f288c60232a5339e0ff2fa05779a5e9c74e9fc085c81e931d4a264501e745b",
+                "sha256:7868b8f218bf69a2a15402fde08b08712213a1f4b85a156d90473a6fb6b12b09",
+                "sha256:787954f541ab95d8195d97b0b8cf1dc304424adb1e07365967e656b92b38a699",
+                "sha256:78ac8dd8e18800bb1f97aad0d73f68916592dddf233b99d2b5cabc562088503a",
+                "sha256:79e29fd62fa2f597a6754b247356bda14b866131a22444d67f907d6d341e10f3",
+                "sha256:845a5e2d84389c4ddada1a9b95c055320070f18bb76512608374aca00d22eca8",
+                "sha256:86b036f401895e854de9fefe061518e78d506d8a919cc250dc3416bca03f6f9a",
+                "sha256:87d9951f5a538dd1d016bdc0dcae59241d15fa94860964833a54d18197fcd134",
+                "sha256:8a9c63cde0eaa345795c0fdeb19dc62d22e378c50b0bc67bf4667cd5b482d98b",
+                "sha256:93f3f1aa608380fe294aa4cb82e2afda07a7598e828d0341e124b8fd9327c715",
+                "sha256:9bf4a5626f2a0ea006bf81e8963f498a57a47d58907eaa58f4b3e13be68759d8",
+                "sha256:9d764514d19b4edcc75fd8cb1423448ef393e8b6cbd94f38cab983ab1b75855d",
+                "sha256:a610e0adfcb0fc84ea25f6ea685e39e74cbcd9245a72a9a7aab85ff755a5ed27",
+                "sha256:a81c9ec59ca2303acd1ccd7b9ac409f1e478e40e96f8f79b943be476c5fdb8bb",
+                "sha256:b7006105b10b59971d3b248ad75acc3651c7e4cf54d81694df5a5130a3c3f7ea",
+                "sha256:c07ce8e9eee878a48ebeb32ee661b49504b85e164b05bebf25420705709fdd31",
+                "sha256:c125a02d22c555e68f7433bac8449992fa1cead525399f14e47c2d98f2f0e467",
+                "sha256:c37df2a060cb476d94c047b18572ee2b37c31f831df126c0da3cd9227b39253d",
+                "sha256:c869260aa62cee21c5eb171a466c0572b5e809213612ef8d495268cd2e34f20d",
+                "sha256:c88e8c226473b5549fe9616980ea7ca09289246cfbdf469241edf4741a620004",
+                "sha256:cd1671e9d5ac05ce6aa86874dd8dfa048824d1dbe73060851b310c6c1a201a96",
+                "sha256:cde09c4fdd070772aa2596d97e942eb775a478b32459e042e1be71b739d08b77",
+                "sha256:cf86b4328c204c3f315074a61bc1c06f8a75a8e102359f18ce99fbcbbf1951f0",
+                "sha256:d5bbe0e1511b844794a3be43d6c145001626ba9a6c1db8f84bdc724e91131d9d",
+                "sha256:d895b4c863059a4934d3e874b90998df774644a41b349ebb330f85f11b4ef2c0",
+                "sha256:db034255e72d2995cf581b14bb3fc9c00bdbe6822b49fcd4eef79e1d5f232618",
+                "sha256:dbb3f87e15d3dd76996d604af8678316ad2d7d20faa394e92d9394dfd621fd0c",
+                "sha256:dc80df325b43ffea5cdea2e3eaa97a44f3dd298262b1c7fe9dbb2a9522b956a7",
+                "sha256:dd7200b4c27b68cf9c9646da01647141c6db09f48cc5b51bc588deaf8e98a797",
+                "sha256:df45fac182ebc3c494460c644e853515cc24f5ad9da05f8ffb91da891bfee879",
+                "sha256:e152461e9a0aedec7d37fc66ec0fa635eca984777d3d3c3e36f53bf3d3ceb16e",
+                "sha256:e2396e0678167f2d0c197da942b0b3fb48fee2f0b5915a0feb84d11b6686afe6",
+                "sha256:e76b6fc0d8e9efa39100369a9b3379ce35e20f6c75365653cf58d282ad290f6f",
+                "sha256:ea3c0cb56eadbf4ab2277e7a095676370b3e46dbfc74d5c383bd87b0d6317910",
+                "sha256:ef3f528fe1cc3d139508fe1b22523745aa77b9d6cb5b0bf277f48788ee0b993f",
+                "sha256:fdf7ad455f1916b8ea5cdbc482d379f6daf93f3867b4232d14699867a5a13af7",
+                "sha256:fffe57312a358be6ec6baeb43d253c36e5790e436b7bf5b7a38df360363e88e9"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.10.31"
+            "markers": "python_version >= '3.8'",
+            "version": "==2023.3.23"
         },
         "requests": {
             "hashes": [
@@ -1240,6 +1283,30 @@
             ],
             "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.2"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+                "sha256:62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.1"
+        },
+        "rfc3986": {
+            "hashes": [
+                "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+                "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:540c7d6d26a1178e8e8b37e9ba44573a3cd1464ff6348b99ee7061b95d1c6333",
+                "sha256:dc84400a9d842b3a9c5ff74addd8eb798d155f36c1c91303888e0a66850d2a15"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==13.3.3"
         },
         "ruamel.yaml": {
             "hashes": [
@@ -1293,11 +1360,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077",
-                "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"
+                "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a",
+                "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.6.0"
+            "version": "==67.6.1"
         },
         "six": {
             "hashes": [
@@ -1467,11 +1534,19 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
-                "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"
+                "sha256:5325463a7da2ef0c6bbfefb62a3dc883aebe679984709aee32a317907d0a8d3c",
+                "sha256:f392ef70ad87a672f02519f99967d28a4d3047133e2d1df936511465fbb3791d"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.11.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.7"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
+                "sha256:9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
         },
         "typing-extensions": {
             "hashes": [
@@ -1577,6 +1652,14 @@
             "markers": "python_version < '3.11'",
             "version": "==1.15.0"
         },
+        "zipp": {
+            "hashes": [
+                "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+                "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.15.0"
+        },
         "zope.event": {
             "hashes": [
                 "sha256:73d9e3ef750cca14816a9c322c7250b0d7c9dbc337df5d1b807ff8d3d0b9e97c",
@@ -1586,45 +1669,39 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:008b0b65c05993bb08912f644d140530e775cf1c62a072bf9340c2249e613c32",
-                "sha256:0217a9615531c83aeedb12e126611b1b1a3175013bbafe57c702ce40000eb9a0",
-                "sha256:0fb497c6b088818e3395e302e426850f8236d8d9f4ef5b2836feae812a8f699c",
-                "sha256:17ebf6e0b1d07ed009738016abf0d0a0f80388e009d0ac6e0ead26fc162b3b9c",
-                "sha256:311196634bb9333aa06f00fc94f59d3a9fddd2305c2c425d86e406ddc6f2260d",
-                "sha256:3218ab1a7748327e08ef83cca63eea7cf20ea7e2ebcb2522072896e5e2fceedf",
-                "sha256:404d1e284eda9e233c90128697c71acffd55e183d70628aa0bbb0e7a3084ed8b",
-                "sha256:4087e253bd3bbbc3e615ecd0b6dd03c4e6a1e46d152d3be6d2ad08fbad742dcc",
-                "sha256:40f4065745e2c2fa0dff0e7ccd7c166a8ac9748974f960cd39f63d2c19f9231f",
-                "sha256:5334e2ef60d3d9439c08baedaf8b84dc9bb9522d0dacbc10572ef5609ef8db6d",
-                "sha256:604cdba8f1983d0ab78edc29aa71c8df0ada06fb147cea436dc37093a0100a4e",
-                "sha256:6373d7eb813a143cb7795d3e42bd8ed857c82a90571567e681e1b3841a390d16",
-                "sha256:655796a906fa3ca67273011c9805c1e1baa047781fca80feeb710328cdbed87f",
-                "sha256:65c3c06afee96c654e590e046c4a24559e65b0a87dbff256cd4bd6f77e1a33f9",
-                "sha256:696f3d5493eae7359887da55c2afa05acc3db5fc625c49529e84bd9992313296",
-                "sha256:6e972493cdfe4ad0411fd9abfab7d4d800a7317a93928217f1a5de2bb0f0d87a",
-                "sha256:7579960be23d1fddecb53898035a0d112ac858c3554018ce615cefc03024e46d",
-                "sha256:765d703096ca47aa5d93044bf701b00bbce4d903a95b41fff7c3796e747b1f1d",
-                "sha256:7e66f60b0067a10dd289b29dceabd3d0e6d68be1504fc9d0bc209cf07f56d189",
-                "sha256:8a2ffadefd0e7206adc86e492ccc60395f7edb5680adedf17a7ee4205c530df4",
-                "sha256:959697ef2757406bff71467a09d940ca364e724c534efbf3786e86eee8591452",
-                "sha256:9d783213fab61832dbb10d385a319cb0e45451088abd45f95b5bb88ed0acca1a",
-                "sha256:a16025df73d24795a0bde05504911d306307c24a64187752685ff6ea23897cb0",
-                "sha256:a2ad597c8c9e038a5912ac3cf166f82926feff2f6e0dabdab956768de0a258f5",
-                "sha256:bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671",
-                "sha256:d169ccd0756c15bbb2f1acc012f5aab279dffc334d733ca0d9362c5beaebe88e",
-                "sha256:d514c269d1f9f5cd05ddfed15298d6c418129f3f064765295659798349c43e6f",
-                "sha256:d692374b578360d36568dd05efb8a5a67ab6d1878c29c582e37ddba80e66c396",
-                "sha256:dbaeb9cf0ea0b3bc4b36fae54a016933d64c6d52a94810a63c00f440ecb37dd7",
-                "sha256:dc26c8d44472e035d59d6f1177eb712888447f5799743da9c398b0339ed90b1b",
-                "sha256:e1574980b48c8c74f83578d1e77e701f8439a5d93f36a5a0af31337467c08fcf",
-                "sha256:e74a578172525c20d7223eac5f8ad187f10940dac06e40113d62f14f3adb1e8f",
-                "sha256:e945de62917acbf853ab968d8916290548df18dd62c739d862f359ecd25842a6",
-                "sha256:f0980d44b8aded808bec5059018d64692f0127f10510eca71f2f0ace8fb11188",
-                "sha256:f98d4bd7bbb15ca701d19b93263cc5edfd480c3475d163f137385f49e5b3a3a7",
-                "sha256:fb68d212efd057596dee9e6582daded9f8ef776538afdf5feceb3059df2d2e7b"
+                "sha256:042f2381118b093714081fd82c98e3b189b68db38ee7d35b63c327c470ef8373",
+                "sha256:0ec9653825f837fbddc4e4b603d90269b501486c11800d7c761eee7ce46d1bbb",
+                "sha256:12175ca6b4db7621aedd7c30aa7cfa0a2d65ea3a0105393e05482d7a2d367446",
+                "sha256:1592f68ae11e557b9ff2bc96ac8fc30b187e77c45a3c9cd876e3368c53dc5ba8",
+                "sha256:23ac41d52fd15dd8be77e3257bc51bbb82469cf7f5e9a30b75e903e21439d16c",
+                "sha256:424d23b97fa1542d7be882eae0c0fc3d6827784105264a8169a26ce16db260d8",
+                "sha256:4407b1435572e3e1610797c9203ad2753666c62883b921318c5403fb7139dec2",
+                "sha256:48f4d38cf4b462e75fac78b6f11ad47b06b1c568eb59896db5b6ec1094eb467f",
+                "sha256:4c3d7dfd897a588ec27e391edbe3dd320a03684457470415870254e714126b1f",
+                "sha256:5171eb073474a5038321409a630904fd61f12dd1856dd7e9d19cd6fe092cbbc5",
+                "sha256:5a158846d0fca0a908c1afb281ddba88744d403f2550dc34405c3691769cdd85",
+                "sha256:6ee934f023f875ec2cfd2b05a937bd817efcc6c4c3f55c5778cbf78e58362ddc",
+                "sha256:790c1d9d8f9c92819c31ea660cd43c3d5451df1df61e2e814a6f99cebb292788",
+                "sha256:809fe3bf1a91393abc7e92d607976bbb8586512913a79f2bf7d7ec15bd8ea518",
+                "sha256:87b690bbee9876163210fd3f500ee59f5803e4a6607d1b1238833b8885ebd410",
+                "sha256:89086c9d3490a0f265a3c4b794037a84541ff5ffa28bb9c24cc9f66566968464",
+                "sha256:99856d6c98a326abbcc2363827e16bd6044f70f2ef42f453c0bd5440c4ce24e5",
+                "sha256:aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d",
+                "sha256:af169ba897692e9cd984a81cb0f02e46dacdc07d6cf9fd5c91e81f8efaf93d52",
+                "sha256:b39b8711578dcfd45fc0140993403b8a81e879ec25d53189f3faa1f006087dca",
+                "sha256:b3f543ae9d3408549a9900720f18c0194ac0fe810cecda2a584fd4dca2eb3bb8",
+                "sha256:d0583b75f2e70ec93f100931660328965bb9ff65ae54695fb3fa0a1255daa6f2",
+                "sha256:dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f",
+                "sha256:e538f2d4a6ffb6edfb303ce70ae7e88629ac6e5581870e66c306d9ad7b564a58",
+                "sha256:eba51599370c87088d8882ab74f637de0c4f04a6d08a312dce49368ba9ed5c2a",
+                "sha256:ee4b43f35f5dc15e1fec55ccb53c130adb1d11e8ad8263d68b1284b66a04190d",
+                "sha256:f2363e5fd81afb650085c6686f2ee3706975c54f331b426800b53531191fdf28",
+                "sha256:f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990",
+                "sha256:f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995",
+                "sha256:fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.5.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0"
         }
     }
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,15 @@
 ## Supported Versions
 
 We generally aim to actively support the latest minor version until we release
-the next one (e.g. we will release patches for 0.3.x until we release 0.4.0).
+the next one (e.g. we will release patches for 0.4.x until we release 0.5.0).
 However, note that this project is currently still in an early stage (marked by
 the 0.x.z version number) meaning that the time between such updates may be
 relatively short.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.x   | :white_check_mark: |
+| 0.4.x   | :white_check_mark: |
+| 0.3.x   | :x:                |
 | < 0.3   | :x:                |
 
 ## Reporting a Vulnerability

--- a/docs/source/developers/setup.rst
+++ b/docs/source/developers/setup.rst
@@ -67,11 +67,15 @@ the respective software (linked above) and just follow their installation instru
       $ # !! You should only run the next command if your python version is below 3.10.x !!
       $ sudo apt install software-properties-common
       $ sudo add-apt-repository ppa:deadsnakes/ppa
-      $ sudo apt update && sudo install python3.10 -y
+      $ sudo apt update
+      $ sudo apt install python3.10 -y
       $ # Now check that you have python3.10 running:
       $ python3.10 --version
       Python 3.10.5
-      $ # Install pipenv (if you already had python 3.10 show above, just use "python3" instead of "python3.10")
+      $ # Install pip and tkinter for Python3.10
+      $ # (Ff you already had python 3.10 show above, just use "python3" instead of "python3.10")
+      $ sudo apt install python3.10-pip and python3.10-tk
+      $ # Install pipenv
       $ python3.10 -m pip install pipenv
       $ # Optional: Install jsdoc (only needed to generate documentation)
       $ sudo apt install npm -y
@@ -95,6 +99,8 @@ the respective software (linked above) and just follow their installation instru
       $ # Check your current python version is >= 3.10.0
       $ python3 --version
       Python 3.10.5
+      $ # Install pip and tkinter for Python3
+      $ sudo apt install python3-pip python3-tk -y
       $ # Install pipenv
       $ python3 -m pip install pipenv
       $ # Optional: Install jsdoc (only needed to generate documentation)

--- a/docs/source/users/installation.rst
+++ b/docs/source/users/installation.rst
@@ -127,15 +127,15 @@ the source code and all the dependencies installed. The last line will run the R
 
 .. parsed-literal::
 
-   $ sudo apt install chromium-browser
-   $ pip install pipenv
-   $ cd ~/
-   $ wget https\ :/\ |github_refs_tags_url|\ |version|\ .tar.gz
-   $ tar -xf ./v\ |version|\ .tar.gz
-   $ rm ./v\ |version|\ .tar.gz
-   $ cd research-client-|version|
-   $ python3.10 -m pipenv install
-   $ python3.10 -m pipenv run python ./manage.py run
+   sudo apt install chromium-browser python3-pip python3-tk -y
+   python3.10 -m pip install pipenv
+   cd ~/
+   wget https\ :/\ |github_refs_tags_url|\ |version|\ .tar.gz
+   tar -xf ./v\ |version|\ .tar.gz
+   rm ./v\ |version|\ .tar.gz
+   cd research-client-|version|
+   python3.10 -m pipenv install
+   python3.10 -m pipenv run python ./manage.py run
 
 .. |github_refs_tags_url| replace:: /github.com/lart-bangor/research-client/archive/refs/tags/v
 

--- a/manage.py
+++ b/manage.py
@@ -119,6 +119,15 @@ def main():
         )
     )
     parser_debug.set_defaults(command="debug")
+    parser_debug.add_argument(
+        "--disable-gpu",
+        dest="disable_gpu",
+        action="store_true",
+        help=(
+            "Pass the --disable-gpu flag to created chrome "
+            "instances.\nCan be useful when running in a VM."
+        )
+    )
     parser_docs = subparsers.add_parser(
         "docs",
         help=(
@@ -131,6 +140,15 @@ def main():
         help="run the app from the development environment"
     )
     parser_run.set_defaults(command="run")
+    parser_run.add_argument(
+        "--disable-gpu",
+        dest="disable_gpu",
+        action="store_true",
+        help=(
+            "Pass the --disable-gpu flag to created chrome "
+            "instances.\nCan be useful when running in a VM."
+        )
+    )
     args = parser.parse_args()
     print(f"Workspace path: {WORKSPACE_PATH}.")
     if args.command == "build":
@@ -138,9 +156,9 @@ def main():
     elif args.command == "clean":
         clean(args.clean_env)
     elif args.command == "run":
-        run()
+        run(disable_gpu=args.disable_gpu)
     elif args.command == "debug":
-        debug()
+        debug(disable_gpu=args.disable_gpu)
     elif args.command == "docs":
         docs()
 
@@ -389,28 +407,44 @@ def clean(env: str) -> bool:                                                    
     return not errors
 
 
-def debug() -> bool:
+def debug(disable_gpu: bool = False) -> bool:
     """Debug the app from the development environment and continue in Python interpreter."""
     oldwd: Path = Path.cwd()
     os.chdir(WORKSPACE_PATH)
+    command: list[str] = [
+        M_COMMAND_PYTHON,
+        "-m",
+        QUALIFIED_PKG_NAME,
+        "--debug",
+        "debug"
+    ]
+    if disable_gpu:
+        command.append("--disable-gpu")
     print("Running app...")
     print(f"{INDENT}Working directory is now '{Path.cwd()!s}'.")
-    print(f"{INDENT}Running command: {M_COMMAND_PYTHON} -im {QUALIFIED_PKG_NAME} --debug debug")
-    child = subprocess.run([M_COMMAND_PYTHON, "-im", QUALIFIED_PKG_NAME, "--debug", "debug"])
+    print(f"{INDENT}Running command: {' '.join(command)}")
+    child = subprocess.run(command)
     print(f"{INDENT}Process returned with code '{child.returncode}'.")
     os.chdir(oldwd)
     print("Done.")
     return child.returncode == 0
 
 
-def run() -> bool:
+def run(disable_gpu: bool = False) -> bool:
     """Run the app from the development environment."""
     oldwd: Path = Path.cwd()
     os.chdir(WORKSPACE_PATH)
+    command: list[str] = [
+        M_COMMAND_PYTHON,
+        "-m",
+        QUALIFIED_PKG_NAME
+    ]
+    if disable_gpu:
+        command.append("--disable-gpu")
     print("Running app...")
     print(f"{INDENT}Working directory is now '{Path.cwd()!s}'.")
-    print(f"{INDENT}Running command: {M_COMMAND_PYTHON} -m {QUALIFIED_PKG_NAME}")
-    child = subprocess.run([M_COMMAND_PYTHON, "-m", QUALIFIED_PKG_NAME])
+    print(f"{INDENT}Running command: {' '.join(command)}")
+    child = subprocess.run(command)
     print(f"{INDENT}Process returned with code '{child.returncode}'.")
     os.chdir(oldwd)
     print("Done.")

--- a/manage.py
+++ b/manage.py
@@ -220,33 +220,163 @@ def build() -> bool:                                                            
     # Set up paths
     oldwd: Path = Path.cwd()
     src_dir: Path = WORKSPACE_PATH / QUALIFIED_PKG_NAME
-    pyi_dir: Path = WORKSPACE_PATH / "build" / "pyinstaller"
-    pyi_pkg_dir: Path = pyi_dir / QUALIFIED_PKG_NAME
+    build_dir: Path = WORKSPACE_PATH / "build" / M_PLATFORM_STRING
+    dist_dir: Path = WORKSPACE_PATH / "dist" / M_PLATFORM_STRING
+    pyi_pkg_dir: Path = build_dir / QUALIFIED_PKG_NAME
 
     # Make sure dist dir exists..
-    dist_dir: Path = WORKSPACE_PATH / "dist" / M_PLATFORM_STRING
     if not dist_dir.is_dir():
         dist_dir.mkdir(parents=True)
 
     # Installer name
-    installer_name: str = safe_str(f"{APP_AUTHOR} {APP_NAME} v{APP_VERSION}-{M_PLATFORM_STRING}")
+    pkg_name: str = safe_str(f"{APP_AUTHOR} {APP_NAME} v{APP_VERSION}-{M_PLATFORM_STRING}")
 
     # Clean the source directory
     if not clean("src"):
         return False
 
-    # Make clean copy of source for pyinstaller
-    print("Setting up files for building...")
-    print(f"{INDENT}Creating package directory for pyinstaller...")
-    if not _copy_dir_clean(src_dir, pyi_pkg_dir):
-        print(f"{INDENT}ERROR: Could not copy directory '{src_dir}' to '{pyi_pkg_dir}'.")
-        print("Failed.")
+    # Build with PyInstaller
+    result = _build_pyinstaller(src_dir, build_dir / "pyinstaller", dist_dir, pkg_name)
+    os.chdir(oldwd)
+    if not result:
         return False
+
+    # Make Inno Setup installer if on Windows
+    if M_PLATFORM_SYSTEM == "Windows":
+        result = _build_inno_installer(build_dir / "pyinstaller", dist_dir, pkg_name)
+        os.chdir(oldwd)
+        if not result:
+            return False
+
+    # Build Wheel with Setuptools...
+    result = _build_setuptools_package(src_dir, build_dir / "setuptools", dist_dir)
+    os.chdir(oldwd)
+    if not result:
+        return False
+
+    return True
+
+
+def _build_setuptools_package(src_dir, build_dir: str, dist_dir: str) -> bool:
+    # Make wheel with setuptools
+    print("Running setuptools to build Python wheel...")
+
+    # Make clean copy of package...
+    print(f"{INDENT}Setting up clean copy of source...")
+    if not _copy_dir_clean(src_dir, build_dir / QUALIFIED_PKG_NAME):
+        print(f"{INDENT*2}ERROR: Could not copy directory '{src_dir}' to '{build_dir}'.")
+        print(f"{INDENT*2}!! Failed !!")
+        return False
+    files_to_copy: tuple[str, ...] = (
+        'setup.cfg',
+        'pyproject.toml',
+        'LICENSE',
+        'LICENSE.AGPL-3.0',
+        'LICENSE.EUPL-1.2',
+        'README.rst'
+    )
+    for file in files_to_copy:
+        print(f"{INDENT*2}Copying file {file}.")
+        shutil.copy(src_dir.parent / file, build_dir / file)
+
+    # Set working directory for setuptools
+    os.chdir(build_dir)
+    print(f"{INDENT}Changed current working directory to '{Path.cwd()}'.")
+
+    # Run build
+    print(f"{INDENT}Running 'python -m build'...")
+    try:
+        child = subprocess.run([M_COMMAND_PYTHON, "-m", "build"])
+    except FileNotFoundError:
+        print(
+            f"{INDENT*2}ERROR: Command '{M_COMMAND_PYTHON}' not found. Is the pipenv virtualenv set up correctly?"
+        )
+        print(f"{INDENT*2}!! Failed !!")
+        return False
+    if child.returncode > 0:
+        print(
+            f"{INDENT*2}ERROR: Python returned an error (code: {child.returncode}). "
+            "Are the setuptools and build packages installed?"
+        )
+        print(f"{INDENT*2}!! Failed !!")
+        return False
+
+    # Check that build produced a dist dir
+    if not Path("dist").is_dir():
+        print(f"{INDENT*2}ERROR: Setuptools dist dir at '{build_dir}/dist' not found.")
+        print(f"{INDENT*2} !! Failed !!")
+        return False
+
+    # Move wheel and sdist archive to dist_dir
+    for file in Path("dist").iterdir():
+        print(f"{INDENT*2}Moving file {file}.")
+        file = file.replace(dist_dir / file.name)
+    print(f"{INDENT}Distributables moved to {dist_dir}.")
+
+    return True
+
+
+def _build_inno_installer(pyinstaller_dir: str, dist_dir: str, pkg_name: str) -> bool:
+    # Make Inno Setup installer
+    print("Running Windows installer build with Inno Setup...")
+
+    # Make installer script...
+    print(f"{INDENT}Making installer script...")
+    with open(WORKSPACE_PATH / "windows.iss", "r") as fp:
+        inno_tpl: str = fp.read()
+    inno_tpl = _str_replace_all(
+        inno_tpl,
+        {
+            "APP_NAME": APP_NAME,
+            "APP_VERSION": APP_VERSION,
+            "APP_AUTHOR": APP_AUTHOR,
+            "APP_LONG_AUTHOR": APP_LONG_AUTHOR,
+            "SAFE_APP_NAME": safe_str(APP_NAME),
+            "SAFE_APP_VERSION": safe_str(APP_VERSION),
+            "SAFE_APP_AUTHOR": safe_str(APP_AUTHOR),
+            "SAFE_APP_LONG_AUTHOR": safe_str(APP_LONG_AUTHOR),
+            "APP_URL": APP_URL,
+            "PLATFORM_STRING": M_PLATFORM_STRING,
+            "WORKSPACE_PATH": str(WORKSPACE_PATH),
+        }
+    )
+    inno_script: Path = pyinstaller_dir / "artifacts" / M_PLATFORM_STRING / "windows.iss"
+    with inno_script.open("w+") as fp:
+        fp.write(inno_tpl)
+    try:
+        child = subprocess.run(["iscc", inno_script])
+    except FileNotFoundError:
+        print(
+            f"{INDENT*2}ERROR: Command 'iscc' not found. Is Inno Setup installed an on the path?"
+        )
+        print(f"{INDENT*2}!! Failed !!")
+        return False
+    installer_file = pyinstaller_dir / "dist" / f"{pkg_name}.exe"
+    if not installer_file.exists():
+        print(
+            f"{INDENT}ERROR: Expected installer file '{installer_file}' not found."
+        )
+        return False
+    installer_file = installer_file.replace(dist_dir / installer_file.name)
+    print(f"{INDENT}EXE installer distributable moved to '{installer_file}'.")
+    print(child)
     print("Done.")
+    return True
+
+
+def _build_pyinstaller(src_dir: Path, build_dir: Path, dist_dir: Path, pkg_name: str) -> bool:  # noqa: C901
+    # Make clean copy of source for pyinstaller
+    print("Running PyInstaller build...")
+    print(f"{INDENT}Setting up files for pyinstaller build...")
+    print(f"{INDENT*2}Creating package directory for pyinstaller...")
+    if not _copy_dir_clean(src_dir, build_dir / QUALIFIED_PKG_NAME):
+        print(f"{INDENT*2}ERROR: Could not copy directory '{src_dir}' to '{build_dir}'.")
+        print(f"{INDENT*2}!! Failed !!")
+        return False
 
     # Create PyInstaller runner file..
-    print("Creating runner file for PyInstaller...")
-    runner_path: Path = pyi_dir / f"{safe_str(APP_NAME)}.py"
+    print(f"{INDENT}Creating runner file...")
+    runner_path: Path = build_dir / f"{safe_str(APP_NAME)}.py"
     with runner_path.open("w") as fp:
         fp.writelines(
             [
@@ -261,26 +391,25 @@ def build() -> bool:                                                            
             ]
         )
     if not runner_path.is_file():
-        print("Failed.")
+        print(f"{INDENT*2}!! Failed !!")
         return False
-    print("Done.")
 
     # Set working directory for PyInstaller...
-    os.chdir(pyi_dir)
-    print(f"Changed current working directory to '{Path.cwd()}'.")
+    os.chdir(build_dir)
+    print(f"{INDENT}Changed current working directory to '{Path.cwd()}'.")
 
     # Run PyInstaller...
     import PyInstaller.__main__ as pyi                                          # type: ignore
     pyi_args: list[str] = [
         "--noconfirm", "--log-level=WARN",
-        f"--workpath=artifacts/{M_PLATFORM_STRING}", f"--distpath=dist/{installer_name}",
+        f"--workpath=artifacts/{M_PLATFORM_STRING}", f"--distpath=dist/{pkg_name}",
         "--clean", f"{safe_str(APP_NAME)}.py",
         "--hidden-import", "bottle_websocket",
         "--add-data", f"{str(resources.path('eel', 'eel.js'))}{os.pathsep}eel",
         "--collect-data", QUALIFIED_PKG_NAME,
     ]
     # if SPLASH_IMAGE:
-    #     CURRENTLY BROKEN IN PyInstaller (tcl/tk lib dependency with vcruntime)
+    #     # CURRENTLY BROKEN IN PyInstaller (tcl/tk lib dependency with vcruntime)
     #     pyi_args.append("--splash")
     #     pyi_args.append(SPLASH_IMAGE)
     if platform.system() == "Windows" or platform.system() == "Darwin":
@@ -288,79 +417,41 @@ def build() -> bool:                                                            
             pyi_args.append("-i")
             pyi_args.append(SPLASH_IMAGE)
         # pyi_args.append("--windowed")
-    print("Running PyInstaller...")
-    print(f"{INDENT}Arguments:")
+    print(f"{INDENT}Running PyInstaller...")
+    print(f"{INDENT*2}Arguments:")
     for i in range(0, len(pyi_args), 2):
-        print(f"{INDENT}{INDENT}{pyi_args[i]}", end="")
+        print(f"{INDENT*3}{pyi_args[i]}", end="")
         if i+1 < len(pyi_args):
             print(f" {pyi_args[i+1]}", end="")
         print("")
     pyi.run(pyi_args)                                                           # type: ignore
-    pyi_dist_dir: Path = pyi_dir / "dist" / f"{installer_name}"
-    if not pyi_dist_dir.is_dir():
-        print(f"{INDENT}ERROR: PyInstaller dist dir at '{pyi_dist_dir}' not found.")
-        print("Failed.")
+    if not Path(f"dist/{pkg_name}").is_dir():
+        print(f"{INDENT*2}ERROR: PyInstaller dist dir at 'dist/{pkg_name}' not found.")
+        print(f"{INDENT*2} !! Failed !!")
         return False
-    print(f"{INDENT}Success: PyInstaller distribution at '{pyi_dist_dir}'.")
-    print("Done.")
-
-    # Set working directory for archiving...
-    os.chdir(pyi_dist_dir)
-    print(f"Changed current working directory to '{Path.cwd()}'.")
+    print(f"{INDENT*2}Success: PyInstaller distribution at 'dist/{pkg_name}'.")
 
     # Make distributable archive
+    print(f"{INDENT}Making archive from PyInstaller build...")
+
+    # Set working directory for archiving...
+    os.chdir(f"dist")
+    print(f"{INDENT*2}Changed current working directory to '{Path.cwd()}'.")
+
+    # Make the archive
     archive_format: str = "zip"
     if platform.system() == "Linux":
         archive_format = "gztar"
-    print(f"Packaging distributable {archive_format.upper()} from PyInstaller distribution...")
-    archive_file = Path(shutil.make_archive(str(pyi_dist_dir), archive_format))
+    print(f"{INDENT*2}Packaging distributable {archive_format.upper()} from PyInstaller distribution...")
+    archive_file = Path(shutil.make_archive(
+        base_name=pkg_name,
+        format=archive_format,
+        root_dir=pkg_name,
+        base_dir=safe_str(APP_NAME)
+    ))
     archive_file = archive_file.replace(dist_dir / archive_file.name)
-    print(f"{INDENT}ZIP distributable moved to '{archive_file}'.")
-    print("Done.")
+    print(f"{INDENT}Archive with distributable moved to '{archive_file}'.")
 
-    # Make Inno Setup installer
-    if M_PLATFORM_SYSTEM == "Windows":
-        print("Building Windows installer with Inno Setup...")
-        with open(WORKSPACE_PATH / "windows.iss", "r") as fp:
-            inno_tpl: str = fp.read()
-        inno_tpl = _str_replace_all(
-            inno_tpl,
-            {
-                "APP_NAME": APP_NAME,
-                "APP_VERSION": APP_VERSION,
-                "APP_AUTHOR": APP_AUTHOR,
-                "APP_LONG_AUTHOR": APP_LONG_AUTHOR,
-                "SAFE_APP_NAME": safe_str(APP_NAME),
-                "SAFE_APP_VERSION": safe_str(APP_VERSION),
-                "SAFE_APP_AUTHOR": safe_str(APP_AUTHOR),
-                "SAFE_APP_LONG_AUTHOR": safe_str(APP_LONG_AUTHOR),
-                "APP_URL": APP_URL,
-                "PLATFORM_STRING": M_PLATFORM_STRING,
-                "WORKSPACE_PATH": str(WORKSPACE_PATH),
-            }
-        )
-        inno_script: Path = pyi_dir / "artifacts" / M_PLATFORM_STRING / "windows.iss"
-        with inno_script.open("w+") as fp:
-            fp.write(inno_tpl)
-        try:
-            child = subprocess.run(["iscc", inno_script])
-        except FileNotFoundError:
-            print(
-                f"{INDENT}ERROR: Command 'iscc' not found. Is Inno Setup installed an on the path?"
-            )
-            return False
-        installer_file = pyi_dist_dir.with_suffix(pyi_dist_dir.suffix + ".exe")
-        if not installer_file.exists():
-            print(
-                f"{INDENT}ERROR: Expected installer file '{installer_file}' not found."
-            )
-            return False
-        installer_file = installer_file.replace(dist_dir / installer_file.name)
-        print(f"{INDENT}EXE installer distributable moved to '{archive_file}'.")
-        print(child)
-        print("Done.")
-
-    os.chdir(oldwd)
     return True
 
 
@@ -376,16 +467,16 @@ def _str_replace_all(
 
 
 def _copy_dir_clean(source: Path, dest: Path):
-    print(f"{INDENT}Copying contents of source directory...")
-    print(f"{INDENT}{INDENT}Source: '{source}'.")
-    print(f"{INDENT}{INDENT}Destination: '{dest}'.")
+    print(f"{INDENT*2}Copying contents of source directory...")
+    print(f"{INDENT*3}Source: '{source}'.")
+    print(f"{INDENT*3}Destination: '{dest}'.")
     _recursively_delete_dir(dest)
     try:
         shutil.copytree(source, dest)
     except OSError as exc:
-        print(f"{INDENT}ERROR: {exc}.")
+        print(f"{INDENT*3}ERROR: {exc}.")
+        print(f"{INDENT*3}!! Failed !!")
         return False
-    print(f"{INDENT}Done.")
     return True
 
 

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Script to automate common project management tasks.
 
 The goal is to eventually implement the following functionality:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/research_client/app.py
+++ b/research_client/app.py
@@ -163,20 +163,33 @@ def main():                                                                     
     try:
         eel.start(
             "app/index.html",
+            mode="chrome",
             jinja_templates="app",
             close_callback=close,
             block=False,
             cmdline_args=cmdline_args
         )
     except OSError as exc:
-        logger.critical(str(exc))
-        show_error_dialog(
-            "Chrome not installed",
-            (
-                "Can't find Google Chrome/Chromium installation.\n\n"
-                "Please install Google Chrome/Chromium before running the Research Client."
+        logger.warning("Chrome not found... attempting fallback to Edge.")
+        try:
+            eel.start(
+                "app/index.html",
+                mode="edge",
+                jinja_templates="app",
+                close_callback=close,
+                block=False,
+                cmdline_args=cmdline_args
             )
-        )
+        except OSError as exc2:
+            logger.critical(str(exc2))
+            show_error_dialog(
+                "Missing Chrome or Edge installation",
+                (
+                    "Can't find Google Chrome/Chromium or Microsoft Edge installation.\n\n"
+                    "Please install either Google Chrome/Chromium or Microsoft Edge before running the Research Client."
+                )
+            )
+            raise
     logger.info(
         f"Now running on "
         f"http://{eel._start_args['host']}:{eel._start_args['port']}"           # type: ignore

--- a/research_client/app.py
+++ b/research_client/app.py
@@ -114,6 +114,16 @@ def main():                                                                     
         )
     )
 
+    argparser.add_argument(
+        "--disable-gpu",
+        dest="disable_gpu",
+        action="store_true",
+        help=(
+            "Pass the --disable-gpu flag to created chrome "
+            "instances.\nCan be useful when running in a VM."
+        )
+    )
+
     args = argparser.parse_args()
     logger.debug("Starting with command line arguments: %s", args)
     try:
@@ -137,17 +147,26 @@ def main():                                                                     
         else:
             sys.exit(1)
 
+    # Check args.disable_gpu
+    if args.disable_gpu:
+        logger.info("Running with --disable-gpu flag.")
+
     # Run app using eel
     eel.init(
         str(Path(__file__).parent / "web"),
         allowed_extensions=[".html", ".js", ".css", ".woff", ".svg", ".svgz", ".png", ".mp3"]
     )
+    # Further arguments for the eel/chrome launch
+    cmdline_args: list[str] = []
+    if args.disable_gpu:
+        cmdline_args.append("--disable-gpu")
     try:
         eel.start(
             "app/index.html",
             jinja_templates="app",
             close_callback=close,
-            block=False
+            block=False,
+            cmdline_args=cmdline_args
         )
     except OSError as exc:
         logger.critical(str(exc))

--- a/research_client/web/app/index.html
+++ b/research_client/web/app/index.html
@@ -33,8 +33,5 @@
         <div class="container-fluid text-center p-2">
             <a class="btn btn-primary fs-5 p-2" href="memorygame/index.html">Memory Task</a>
         </div>
-        <div class="container-fluid text-center p-2">
-            <a class="btn btn-primary fs-5 p-2" href="conclusion/index.html">Conclusion</a>
-        </div>
     </article>
 {% endblock %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.3.6post2
+version = 0.4.0
 name = research_client
 author = Florian Breit, Marco Tamburelli
 author_email = f.breit@bangor.ac.uk
@@ -12,7 +12,10 @@ license_files =
   LICENSE.EUPL-1.2
 url = https://github.com/lart-bangor/lart-research-client
 project_urls =
-  Bug Tracker = https://github.com/lart-bangor/lart-research-client/issues
+  Documentation = https://research-client.readthedocs.io/
+  Bug Tracker = https://github.com/lart-bangor/research-client/issues
+  Support = https://github.com/lart-bangor/research-client/discussions
+  Source = https://github.com/lart-bangor/research-client
 classifiers =
   Development Status :: 4 - Beta
   Intended Audience :: Education

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,47 +1,60 @@
 [metadata]
-version = 0.3.6
+version = 0.3.6post2
 name = research_client
 author = Florian Breit, Marco Tamburelli
 author_email = f.breit@bangor.ac.uk
 description = An app that aims to make life easier for researchers working on bilingualism, sociolinguistics, language attitudes, and regional/minority/minoritized languages.
-long_description = file: README.md
-long_description_content_type = text/markdown
-license = AGPLv3+ or EUPL-1.2
-license_files = LICENSE
+long_description = file: README.rst
+license = AGPLv3-or-later OR EUPL-1.2+
+license_files =
+  LICENSE
+  LICENSE.AGPL-3.0
+  LICENSE.EUPL-1.2
 url = https://github.com/lart-bangor/lart-research-client
 project_urls =
-    Bug Tracker = https://github.com/lart-bangor/lart-research-client/issues
+  Bug Tracker = https://github.com/lart-bangor/lart-research-client/issues
 classifiers =
-    Development Status :: 4 - Beta
-    Intended Audience :: Education
-    Intended Audience :: Science/Research
-    Intended Audience :: End Users/Desktop
-    License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
-    License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)
-    Natural Language :: English
-    Natural Language :: German
-    Natural Language :: Italian
-    Natural Language :: Greek
-    Natural Language :: Welsh
-    Operating System :: Microsoft :: Windows :: Windows 10
-    Operating System :: Microsoft :: Windows :: Windows 11
-    Operating System :: POSIX :: Linux
-    Operating System :: MacOS
-    Programming Language :: Python :: 3.10
-    Programming Language :: JavaScript
-    Topic :: Scientific/Engineering
-    Topic :: Sociology
-    Topic :: Text Processing :: Linguistic
-    Topic :: Utilities
+  Development Status :: 4 - Beta
+  Intended Audience :: Education
+  Intended Audience :: Science/Research
+  Intended Audience :: End Users/Desktop
+  License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
+  License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)
+  Natural Language :: English
+  Natural Language :: German
+  Natural Language :: Italian
+  Natural Language :: Greek
+  Operating System :: Microsoft :: Windows :: Windows 10
+  Operating System :: Microsoft :: Windows :: Windows 11
+  Operating System :: POSIX :: Linux
+  Operating System :: MacOS
+  Programming Language :: Python :: 3.10
+  Programming Language :: JavaScript
+  Topic :: Scientific/Engineering
+  Topic :: Sociology
+  Topic :: Text Processing :: Linguistic
+  Topic :: Utilities
 
 [options]
 zip_safe = False
-include_package_data = True
 packages = find:
-python_requires = >=3.9
+include_package_data = True
+python_requires = >=3.10
 install_requires =
-  eel[jinja2]
-  appdirs
+  greenlet <2.0.0
+  gevent <22.10.0
+  eel[jinja2] ==0.16.0
+  platformdirs ==3.2.0
+
+[options.package_data]
+* =
+  *.json
+research_client =
+  web/**
+
+[options.entry_points]
+console_scripts =
+  research-client = research_client.app:main
 
 [app.options]
 name = Research Client

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Unit tests for the `lart_survey_client` package."""

--- a/windows.iss
+++ b/windows.iss
@@ -31,7 +31,7 @@ DisableProgramGroupPage=yes
 LicenseFile={#MyAppDevDir}\LICENSE.AGPL-3.0
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-OutputDir={#MyAppDevDir}\build\pyinstaller\dist
+OutputDir={#MyAppDevDir}\build\{#MyAppPlatformString}\pyinstaller\dist
 OutputBaseFilename={#MyAppDistributableName}
 OutputManifestFile={#MyAppDistributableName}.manifest
 SetupIconFile={#MyAppDevDir}\research_client\web\img\setupicon.ico
@@ -59,8 +59,8 @@ Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "{#MyAppDevDir}\build\pyinstaller\dist\{#MyAppDistributableName}\{#MySafeAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyAppDevDir}\build\pyinstaller\dist\{#MyAppDistributableName}\{#MySafeAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#MyAppDevDir}\build\{#MyAppPlatformString}\pyinstaller\dist\{#MyAppDistributableName}\{#MySafeAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyAppDevDir}\build\{#MyAppPlatformString}\pyinstaller\dist\{#MyAppDistributableName}\{#MySafeAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
Addresses #38 -- the app now has a new build process to make wheel and sdist packages which can be uploaded to [PyPI](https://pypi.org/project/research-client/) and installed by users with `pip install research-client`.

The PR also improves on #37 by implementing a more differentiated mechanism to exit the event loop, which should be compatible with both *libev* (on Linux/Unix/MacOS) and *libuv* (on Windows), though further testing on MacOS would be a good idea.