### PR TITLE
Improve cross-system/version compatibility

### DIFF
--- a/research_client/config/__init__.py
+++ b/research_client/config/__init__.py
@@ -381,7 +381,7 @@ class Config(DataclassDictMixin, DataclassDocMixin):
     appauthor: str = field(default=_appauthor, init=False)
     appversion: str = field(default="0.3.4", init=False)
     logging: Logging = field(
-        default=Logging(),
+        default_factory=lambda: Logging(),
         metadata={
             "doc_label": "Logging settings",
             "doc_help": (
@@ -395,7 +395,7 @@ class Config(DataclassDictMixin, DataclassDocMixin):
         }
     )
     paths: Paths = field(
-        default=Paths(),
+        default_factory=lambda: Paths(),
         metadata={
             "doc_label": "Path and directory settings",
             "doc_help": (
@@ -414,7 +414,7 @@ class Config(DataclassDictMixin, DataclassDocMixin):
         }
     )
     sequences: Sequences = field(
-        default=Sequences(),
+        default_factory=lambda: Sequences(),
         metadata={
             "doc_label": "Task sequencing",
             "doc_help": (

--- a/research_client/settings/eel.py
+++ b/research_client/settings/eel.py
@@ -65,13 +65,12 @@ def load() -> dict[str, dict[str, Any]]:
         "help": "General app settings.",
         "fields": fields,
     }
-    # Add sub-configuration sections
     for dataclass in dataclasses:
         settings[dataclass["name"]] = dataclass
         # Remove irrelevant/redundant attributes
-        del settings[dataclass["name"]]["value"]
-        del settings[dataclass["name"]]["type"]
-        del settings[dataclass["name"]]["default"]
+        for key in ("value", "type", "default"):
+            if key in settings[dataclass["name"]]:
+                del settings[dataclass["name"]][key]
         # Remove sub-dataclasses from fields attribute
         settings[dataclass["name"]]["fields"] = settings[dataclass["name"]]["fields"][1]
         # For Path type arguments, convert default and value to string


### PR DESCRIPTION
A small change in the config/settings handling to use `default_factory`. This is needed for forward compatibility with Python >= 3.11, and allows the app to be installed much more easily with tools such as `pipx` on Linux and other systems which may by default have Python > 3.10.